### PR TITLE
Fix quicksol_estate installation error

### DIFF
--- a/quicksol_estate/__manifest__.py
+++ b/quicksol_estate/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Real Estate Management',
-    'version': '18.0.1',
+    'version': '18.0.1.0.0',
     'category': 'Real Estate',
     'summary': 'Manage properties, sales, leases, tenants, and agents',
     'description': """

--- a/quicksol_estate/models/property.py
+++ b/quicksol_estate/models/property.py
@@ -15,6 +15,7 @@ class Property(models.Model):
     city = fields.Char(string='City')
     state = fields.Char('State')
     zip_code = fields.Char('Zip Code')
+    description = fields.Text(string='Description')
     latitude = fields.Float('Latitude')
     longitude = fields.Float('Longitude')
     country_id = fields.Many2one('res.country', string='Country')

--- a/quicksol_estate/views/property_views.xml
+++ b/quicksol_estate/views/property_views.xml
@@ -18,6 +18,7 @@
                         <field name="state"/>
                         <field name="country_id"/>
                         <field name="zip_code"/>
+                        <field name="description"/>
                     </group>
                     <group>
                         <field name="property_type_id"/>


### PR DESCRIPTION
## Summary
- add a description field to real estate properties
- show the description on the property form

## Testing
- `python -m py_compile quicksol_estate/*.py quicksol_estate/models/*.py`


------
https://chatgpt.com/codex/tasks/task_e_687de4ca1314832aa6d212b359fd8099