### PR TITLE
Add core models for realestate_mlr module

### DIFF
--- a/realestate_mlr/__init__.py
+++ b/realestate_mlr/__init__.py
@@ -1,0 +1,3 @@
+from . import models
+
+__all__ = ["models"]

--- a/realestate_mlr/__manifest__.py
+++ b/realestate_mlr/__manifest__.py
@@ -1,0 +1,26 @@
+{
+    'name': 'Real Estate Management MLR',
+    'version': '18.0.1.0.0',
+    'category': 'Real Estate',
+    'summary': 'Manage regions, projects, properties, and units',
+    'description': """\
+Real Estate Management Module
+Phase 1 implements core models for regions, projects, properties, and units.
+""",
+    'author': 'Your Company Name',
+    'website': 'https://yourcompany.example.com',
+    'depends': ['base'],
+    'data': [
+        'security/realestate_security.xml',
+        'security/ir.model.access.csv',
+        'views/region_views.xml',
+        'views/project_views.xml',
+        'views/property_views.xml',
+        'views/unit_views.xml',
+        'views/realestate_menus.xml',
+    ],
+    'license': 'LGPL-3',
+    'installable': True,
+    'auto_install': False,
+    'application': True,
+}

--- a/realestate_mlr/models/__init__.py
+++ b/realestate_mlr/models/__init__.py
@@ -1,0 +1,4 @@
+from . import region
+from . import project
+from . import property
+from . import unit

--- a/realestate_mlr/models/project.py
+++ b/realestate_mlr/models/project.py
@@ -1,0 +1,12 @@
+from odoo import models, fields
+
+
+class RealEstateProject(models.Model):
+    _name = 'realestate.project'
+    _description = 'Real Estate Project'
+    _order = 'name'
+
+    name = fields.Char(required=True, translate=True)
+    region_id = fields.Many2one('realestate.region', string='Region')
+    description = fields.Text(translate=True)
+    property_ids = fields.One2many('realestate.property', 'project_id', string='Properties')

--- a/realestate_mlr/models/property.py
+++ b/realestate_mlr/models/property.py
@@ -1,0 +1,18 @@
+from odoo import models, fields
+
+
+class RealEstateProperty(models.Model):
+    _name = 'realestate.property'
+    _description = 'Property'
+    _order = 'name'
+
+    name = fields.Char(required=True, translate=True)
+    project_id = fields.Many2one('realestate.project', string='Project')
+    property_type = fields.Selection([
+        ('building', 'Building'),
+        ('villa', 'Villa'),
+        ('land', 'Land'),
+    ], string='Property Type', default='building')
+    address = fields.Char()
+    description = fields.Text(translate=True)
+    unit_ids = fields.One2many('realestate.unit', 'property_id', string='Units')

--- a/realestate_mlr/models/region.py
+++ b/realestate_mlr/models/region.py
@@ -1,0 +1,12 @@
+from odoo import models, fields
+
+
+class RealEstateRegion(models.Model):
+    _name = 'realestate.region'
+    _description = 'Region'
+    _order = 'name'
+
+    name = fields.Char(required=True, translate=True)
+    code = fields.Char(help='Short code for the region')
+    description = fields.Text(translate=True)
+    project_ids = fields.One2many('realestate.project', 'region_id', string='Projects')

--- a/realestate_mlr/models/unit.py
+++ b/realestate_mlr/models/unit.py
@@ -1,0 +1,19 @@
+from odoo import models, fields
+
+
+class RealEstateUnit(models.Model):
+    _name = 'realestate.unit'
+    _description = 'Property Unit'
+    _order = 'name'
+
+    name = fields.Char(required=True, translate=True)
+    property_id = fields.Many2one('realestate.property', string='Property', required=True)
+    floor = fields.Char(string='Floor/Number')
+    area = fields.Float(string='Area (sqm)')
+    status = fields.Selection([
+        ('available', 'Available'),
+        ('reserved', 'Reserved'),
+        ('sold', 'Sold'),
+        ('rented', 'Rented'),
+    ], default='available')
+    description = fields.Text(translate=True)

--- a/realestate_mlr/security/ir.model.access.csv
+++ b/realestate_mlr/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_realestate_region,access_realestate_region,model_realestate_region,group_realestate_user,1,1,1,1
+access_realestate_project,access_realestate_project,model_realestate_project,group_realestate_user,1,1,1,1
+access_realestate_property,access_realestate_property,model_realestate_property,group_realestate_user,1,1,1,1
+access_realestate_unit,access_realestate_unit,model_realestate_unit,group_realestate_user,1,1,1,1

--- a/realestate_mlr/security/realestate_security.xml
+++ b/realestate_mlr/security/realestate_security.xml
@@ -1,0 +1,5 @@
+<odoo>
+    <record id="group_realestate_user" model="res.groups">
+        <field name="name">Real Estate User</field>
+    </record>
+</odoo>

--- a/realestate_mlr/views/project_views.xml
+++ b/realestate_mlr/views/project_views.xml
@@ -1,0 +1,34 @@
+<odoo>
+    <record id="view_realestate_project_tree" model="ir.ui.view">
+        <field name="name">realestate.project.tree</field>
+        <field name="model">realestate.project</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="region_id"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_realestate_project_form" model="ir.ui.view">
+        <field name="name">realestate.project.form</field>
+        <field name="model">realestate.project</field>
+        <field name="arch" type="xml">
+            <form string="Project">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="region_id"/>
+                        <field name="description"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_realestate_project" model="ir.actions.act_window">
+        <field name="name">Projects</field>
+        <field name="res_model">realestate.project</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+</odoo>

--- a/realestate_mlr/views/property_views.xml
+++ b/realestate_mlr/views/property_views.xml
@@ -1,0 +1,48 @@
+<odoo>
+    <record id="view_realestate_property_tree" model="ir.ui.view">
+        <field name="name">realestate.property.tree</field>
+        <field name="model">realestate.property</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="project_id"/>
+                <field name="property_type"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_realestate_property_form" model="ir.ui.view">
+        <field name="name">realestate.property.form</field>
+        <field name="model">realestate.property</field>
+        <field name="arch" type="xml">
+            <form string="Property">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="project_id"/>
+                        <field name="property_type"/>
+                        <field name="address"/>
+                        <field name="description"/>
+                    </group>
+                    <notebook>
+                        <page string="Units">
+                            <field name="unit_ids">
+                                <tree editable="bottom">
+                                    <field name="name"/>
+                                    <field name="floor"/>
+                                    <field name="status"/>
+                                </tree>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_realestate_property" model="ir.actions.act_window">
+        <field name="name">Properties</field>
+        <field name="res_model">realestate.property</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+</odoo>

--- a/realestate_mlr/views/realestate_menus.xml
+++ b/realestate_mlr/views/realestate_menus.xml
@@ -1,0 +1,8 @@
+<odoo>
+    <menuitem id="menu_realestate_root" name="Real Estate" sequence="10"/>
+
+    <menuitem id="menu_realestate_regions" name="Regions" parent="menu_realestate_root" action="action_realestate_region" sequence="10"/>
+    <menuitem id="menu_realestate_projects" name="Projects" parent="menu_realestate_root" action="action_realestate_project" sequence="20"/>
+    <menuitem id="menu_realestate_properties" name="Properties" parent="menu_realestate_root" action="action_realestate_property" sequence="30"/>
+    <menuitem id="menu_realestate_units" name="Units" parent="menu_realestate_root" action="action_realestate_unit" sequence="40"/>
+</odoo>

--- a/realestate_mlr/views/region_views.xml
+++ b/realestate_mlr/views/region_views.xml
@@ -1,0 +1,35 @@
+<odoo>
+    <record id="view_realestate_region_tree" model="ir.ui.view">
+        <field name="name">realestate.region.tree</field>
+        <field name="model">realestate.region</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="code"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_realestate_region_form" model="ir.ui.view">
+        <field name="name">realestate.region.form</field>
+        <field name="model">realestate.region</field>
+        <field name="arch" type="xml">
+            <form string="Region">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="code"/>
+                        <field name="description"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_realestate_region" model="ir.actions.act_window">
+        <field name="name">Regions</field>
+        <field name="res_model">realestate.region</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+</odoo>

--- a/realestate_mlr/views/unit_views.xml
+++ b/realestate_mlr/views/unit_views.xml
@@ -1,0 +1,38 @@
+<odoo>
+    <record id="view_realestate_unit_tree" model="ir.ui.view">
+        <field name="name">realestate.unit.tree</field>
+        <field name="model">realestate.unit</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="property_id"/>
+                <field name="status"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_realestate_unit_form" model="ir.ui.view">
+        <field name="name">realestate.unit.form</field>
+        <field name="model">realestate.unit</field>
+        <field name="arch" type="xml">
+            <form string="Unit">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                        <field name="property_id"/>
+                        <field name="floor"/>
+                        <field name="area"/>
+                        <field name="status"/>
+                        <field name="description"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_realestate_unit" model="ir.actions.act_window">
+        <field name="name">Units</field>
+        <field name="res_model">realestate.unit</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- scaffold `realestate_mlr` module
- add models for regions, projects, properties and units
- add menus, actions and basic views
- define security group and model access rights

## Testing
- `python -m py_compile realestate_mlr/**/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687dfab93bf0832aa3f56082e7204501